### PR TITLE
fix(icon-patcher): also set CFBundleIconName

### DIFF
--- a/lib/fastlane/plugin/act/helper/icon_patcher.rb
+++ b/lib/fastlane/plugin/act/helper/icon_patcher.rb
@@ -28,6 +28,11 @@ module Fastlane
           icons.map { |i| i[:name] }.uniq.each_with_index do |key, index|
             plist_buddy.exec("Add #{icons_plist_key}:#{index} string #{key}")
           end
+
+          icon_filename = File.basename(iconset_path)
+          icon_excluding_file_type = icon_filename.split('.')[0]
+          icon_name_plist_key = ":CFBundleIcons#{idiom_suffix}:CFBundlePrimaryIcon:CFBundleIconName"
+          plist_buddy.exec("Add #{icon_name_plist_key} string #{icon_excluding_file_type}")
         end
 
         archive.replace(plist_path)
@@ -88,6 +93,7 @@ module Fastlane
           plist_buddy.exec "Delete #{icon_list_key}"
         end
       end
+
     end
   end
 end

--- a/spec/act_action_ipa_spec.rb
+++ b/spec/act_action_ipa_spec.rb
@@ -174,6 +174,20 @@ describe Fastlane::Actions::ActAction do
           expect(result).to eql(["Blue29x29", "Blue40x40"])
         end
 
+
+        it 'sets the Icon Name to be the same as the iconset' do
+          Fastlane::Actions::ActAction.run(
+            archive_path: @ipa_file,
+            iconset: "example/Blue.appiconset"
+          )
+
+          result = [
+            invoke_plistbuddy("Print :CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName", "Payload/Example.app/Info.plist")
+          ]
+
+          expect(result).to eql(["Blue"])
+        end
+
         # TODO: More tests for other idioms (ie. iPad icons). These are supported, but there's no tests yet
 
         it 'ignores :plist_file option' do

--- a/spec/act_action_xcarchive_spec.rb
+++ b/spec/act_action_xcarchive_spec.rb
@@ -175,6 +175,19 @@ describe Fastlane::Actions::ActAction do
           expect(result).to eql(["Blue29x29", "Blue40x40"])
         end
 
+        it 'sets the Icon Name to be the same as the iconset' do
+          Fastlane::Actions::ActAction.run(
+            archive_path: @archive_path,
+            iconset: "example/Blue.appiconset"
+          )
+
+          result = [
+            invoke_plistbuddy("Print :CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName", "Products/Applications/Example.app/Info.plist")
+          ]
+
+          expect(result).to eql(["Blue"])
+        end
+
         # TODO: More tests for other idioms (ie. iPad icons). These are supported, but there's no tests yet
 
         it 'ignores :plist_file option' do
@@ -189,6 +202,8 @@ describe Fastlane::Actions::ActAction do
           expect(result).to be true
         end
       end
+
+      context 'providing an iconma'
 
       def invoke_plistbuddy(command, plist)
         return `/usr/libexec/PlistBuddy -c "#{command}" #{@archive_path.shellescape}/#{plist.shellescape}`.strip


### PR DESCRIPTION
Required by iOS 11. Assuming that CFBundleIconName is the same as the name of the iconset (to avoid exposing an additional required property).