### PR TITLE
When trying to replace, add the file if it not already exists

### DIFF
--- a/example/Foo.plist
+++ b/example/Foo.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Foo</key>
+	<integer>42</integer>
+</dict>
+</plist>

--- a/lib/fastlane/plugin/act/helper/file_patcher.rb
+++ b/lib/fastlane/plugin/act/helper/file_patcher.rb
@@ -8,7 +8,7 @@ module Fastlane
           relative_path = ActHelper::ArchivePaths.expand(archive, old_file)
           local_path = archive.local_path(relative_path)
 
-          archive.extract(relative_path)
+          `mkdir -p #{File.dirname(local_path).shellescape}`
           `cp #{new_file.shellescape} #{local_path.shellescape}`
           archive.replace(relative_path)
         end

--- a/spec/act_action_ipa_spec.rb
+++ b/spec/act_action_ipa_spec.rb
@@ -215,6 +215,19 @@ describe Fastlane::Actions::ActAction do
 
           expect(result).to eql("NewExample")
         end
+
+        it 'adds if there is no file to replace' do
+          Fastlane::Actions::ActAction.run(
+            archive_path: @ipa_file,
+            replace_files: {
+              "Foo.plist" => "example/Foo.plist"
+            }
+          )
+
+          result = invoke_plistbuddy("Print :Foo", "Payload/Example.app/Foo.plist")
+
+          expect(result).to eql("42")
+        end
       end
 
       context 'delete files' do

--- a/spec/act_action_xcarchive_spec.rb
+++ b/spec/act_action_xcarchive_spec.rb
@@ -216,6 +216,19 @@ describe Fastlane::Actions::ActAction do
 
           expect(result).to eql("NewExample")
         end
+
+        it 'adds if there is no file to replace' do
+          Fastlane::Actions::ActAction.run(
+            archive_path: @archive_path,
+            replace_files: {
+              "/Foo.plist" => "example/Foo.plist"
+            }
+          )
+
+          result = invoke_plistbuddy("Print :Foo", "Foo.plist")
+
+          expect(result).to eql("42")
+        end
       end
 
       context 'delete files' do


### PR DESCRIPTION
The current behaviour is to fail if the target file does not already exists. This has been changed so that the new file is added.